### PR TITLE
Update dependency versions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>31.1-jre</version>
+            <version>20.0</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>com.indeed</groupId>
     <artifactId>mph-table</artifactId>
     <name>indeed-mph-table</name>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>1.0.7-SNAPSHOT</version>
     <description>
         Minimal Perfect Hash Tables
     </description>
@@ -46,9 +46,9 @@
     <dependencies>
 
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.14</version>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
+            <version>1.2.25</version>
         </dependency>
 
         <dependency>
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>16.0.1</version>
+            <version>31.1-jre</version>
         </dependency>
 
         <dependency>
@@ -140,7 +140,7 @@
 
         <!-- releases of our own projects to use -->
         <!-- these should only be SNAPSHOTs when no release is available -->
-        <indeed-util.version>1.0.24</indeed-util.version>
+        <indeed-util.version>1.0.52-3042601</indeed-util.version>
         <fastutil.version>6.5.15</fastutil.version>
 
         <!-- these versions should be kept in lockstep across multiple dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>com.indeed</groupId>
     <artifactId>mph-table</artifactId>
     <name>indeed-mph-table</name>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>1.0.6</version>
     <description>
         Minimal Perfect Hash Tables
     </description>


### PR DESCRIPTION
A new version of com.indeed:util-mmap was released recently to enable Java 17 support. This MR updates that dependency and a couple of others that were showing in Maven Central as having vulnerabilities.